### PR TITLE
Update pom.xml to set the liberty-maven-plugin version to 1.3 instead of 1.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -182,7 +182,7 @@
 			<plugin>
 				<groupId>net.wasdev.wlp.maven.plugins</groupId>
 				<artifactId>liberty-maven-plugin</artifactId>
-				<version>1.2-SNAPSHOT</version>
+				<version>1.3-SNAPSHOT</version>
 
 				<executions>
 					<execution>


### PR DESCRIPTION
Update pom.xml file to use correct liberty-maven-plugin version